### PR TITLE
adding default route to DHCP OPNFV JIRA BGS-84

### DIFF
--- a/roles/foreman/opnfv-install/templates/dhcp_extra_subnets.j2
+++ b/roles/foreman/opnfv-install/templates/dhcp_extra_subnets.j2
@@ -35,6 +35,7 @@ subnet {{ ansible_enp0s16.ipv4.network }} netmask {{ ansible_enp0s16.ipv4.netmas
   }
 
   option subnet-mask {{ ansible_enp0s16.ipv4.netmask }};
+  option routers {{ ansible_default_ipv4.gateway }};
 }
 
 {% endif %}


### PR DESCRIPTION
By adding the default route to the public nework on DHCP
it will overried the admin network, once the public interface
is active.

No changes are needed on the individual nodes.  They will continue
to use the admin network for the PXE install.
