### PR TITLE
Moved default route to correct subnet

### DIFF
--- a/roles/foreman/opnfv-install/templates/dhcp_extra_subnets.j2
+++ b/roles/foreman/opnfv-install/templates/dhcp_extra_subnets.j2
@@ -21,6 +21,7 @@ subnet {{ ansible_enp0s10.ipv4.network }} netmask {{ ansible_enp0s10.ipv4.netmas
   }
 
   option subnet-mask {{ ansible_enp0s10.ipv4.netmask }};
+  option routers {{ ansible_default_ipv4.gateway }};
 }
 
 {% if network_type == "multi_network" %}
@@ -35,7 +36,6 @@ subnet {{ ansible_enp0s16.ipv4.network }} netmask {{ ansible_enp0s16.ipv4.netmas
   }
 
   option subnet-mask {{ ansible_enp0s16.ipv4.netmask }};
-  option routers {{ ansible_default_ipv4.gateway }};
 }
 
 {% endif %}


### PR DESCRIPTION
Previous patch added the new DHCP default route to the storage 
network instead of the public network.

This patch corrects that and adds the default route to the correct
subnet stanza.
